### PR TITLE
Fix NameError 'err'->'e' in DaemonLite.stop

### DIFF
--- a/DaemonLite.py
+++ b/DaemonLite.py
@@ -146,7 +146,7 @@ class DaemonLite(object) :
                 if os.path.exists(self.pidFile):
                     os.remove(self.pidFile)
             else :
-                print(str(err))
+                print(str(e))
                 sys.exit(1)
 
         if self.verbose >= 1:


### PR DESCRIPTION
Fixes a typo that leads to:

      File "/usr/local/lib/python3.4/dist-packages/DaemonLite.py", line 149, in stop
        print(str(err))
    NameError: name 'err' is not defined